### PR TITLE
Allow Escaping "Split" Tokens - fixes #15

### DIFF
--- a/scripts/activity-diagram.js
+++ b/scripts/activity-diagram.js
@@ -19,7 +19,7 @@ module.exports = function(specLines, options)
     function parseYumlExpr(specLine)
     {
         var exprs = [];
-        var parts = this.splitYumlExpr(specLine, "(<|");
+        var parts = this.splitYumlExpr(specLine, "(<|", '\\');
 
         for (var i=0; i<parts.length; i++)
         {

--- a/scripts/class-diagram.js
+++ b/scripts/class-diagram.js
@@ -23,7 +23,7 @@ module.exports = function(specLines, options)
     function parseYumlExpr(specLine)
     {
         var exprs = [];
-        var parts = this.splitYumlExpr(specLine, "[");
+        var parts = this.splitYumlExpr(specLine, "[", "\\");
 
         for (var i=0; i<parts.length; i++)
         {

--- a/scripts/deployment-diagram.js
+++ b/scripts/deployment-diagram.js
@@ -14,7 +14,7 @@ module.exports = function(specLines, options)
     function parseYumlExpr(specLine)
     {
         var exprs = [];
-        var parts = this.splitYumlExpr(specLine, "[");
+        var parts = this.splitYumlExpr(specLine, "[", "\\");
 
         for (var i=0; i<parts.length; i++)
         {

--- a/scripts/package-diagram.js
+++ b/scripts/package-diagram.js
@@ -14,7 +14,7 @@ module.exports = function(specLines, options)
     function parseYumlExpr(specLine)
     {
         var exprs = [];
-        var parts = this.splitYumlExpr(specLine, "[");
+        var parts = this.splitYumlExpr(specLine, "[", "\\");
 
         for (var i=0; i<parts.length; i++)
         {

--- a/scripts/state-diagram.js
+++ b/scripts/state-diagram.js
@@ -16,7 +16,7 @@ module.exports = function(specLines, options)
     function parseYumlExpr(specLine)
     {
         var exprs = [];
-        var parts = this.splitYumlExpr(specLine, "(");
+        var parts = this.splitYumlExpr(specLine, "(", "\\");
 
         for (var i=0; i<parts.length; i++)
         {

--- a/scripts/usecase-diagram.js
+++ b/scripts/usecase-diagram.js
@@ -16,7 +16,7 @@ module.exports = function(specLines, options)
     function parseYumlExpr(specLine)
     {
         var exprs = [];
-        var parts = this.splitYumlExpr(specLine, "[(");
+        var parts = this.splitYumlExpr(specLine, "[(", "\\");
 
         for (var i=0; i<parts.length; i++)
         {

--- a/scripts/yuml2dot-utils.js
+++ b/scripts/yuml2dot-utils.js
@@ -23,7 +23,7 @@ module.exports = function()
         return newlabel;
     }
 
-    this.splitYumlExpr = function(line, separators)
+    this.splitYumlExpr = function(line, separators, escape)
     {
         var word = "";
         var lastChar = null;
@@ -33,7 +33,12 @@ module.exports = function()
         {
             c = line[i];
 
-            if (separators.indexOf(c) >= 0 && lastChar === null)
+            if (c === escape && i + 1 < line.length)
+            {
+                word += c;
+                word += line[++i];
+            }
+            else if (separators.indexOf(c) >= 0 && lastChar === null)
             {
                 if (word.length > 0) {
                     parts.push(word.trim());


### PR DESCRIPTION
Allow using "special" characters by escaping them with "\"