### PR TITLE
Allow Escaping "Split" Tokens - fixes #15

### DIFF
--- a/scripts/yuml2dot-utils.js
+++ b/scripts/yuml2dot-utils.js
@@ -23,7 +23,7 @@ module.exports = function()
         return newlabel;
     }
 
-    this.splitYumlExpr = function(line, separators)
+    this.splitYumlExpr = function(line, separators, escape = "\\")
     {
         var word = "";
         var lastChar = null;
@@ -33,7 +33,12 @@ module.exports = function()
         {
             c = line[i];
 
-            if (separators.indexOf(c) >= 0 && lastChar === null)
+            if (c === escape && i + 1 < line.length)
+            {
+                word += c;
+                word += line[++i];
+            }
+            else if (separators.indexOf(c) >= 0 && lastChar === null)
             {
                 if (word.length > 0) {
                     parts.push(word.trim());


### PR DESCRIPTION
Allow users to escape tokens that are used in splitting lines. As an example, allow the following to work:

```
// {type:activity}
(start)-><a>
<a>[x \< y]->(end)
```