### PR TITLE
Sandbox SVG elements to avoid ID conflicts

### DIFF
--- a/src/yumldoc-utils.js
+++ b/src/yumldoc-utils.js
@@ -23,22 +23,14 @@ module.exports = function()
 
         var div = `<div>
     <style>
-        .vscode-high-contrast .yuml-light {
-            display: none;
-        }
-        .vscode-dark .yuml-light {
-            display: none;
-        }
+        .vscode-high-contrast .yuml-light,
+        .vscode-dark .yuml-light,
         .vscode-light .yuml-dark {
             display: none;
         }
     </style>
-    <div class='yuml-light'>
-        ${svgLight}
-    </div>
-    <div class='yuml-dark'>
-        ${svgDark}
-    </div>
+    <img class='yuml-light' src='data:image/svg+xml;base64,${Buffer.from(svgLight).toString('base64')}'>
+    <img class='yuml-dark' src='data:image/svg+xml;base64,${Buffer.from(svgDark).toString('base64')}'>
 </div>`;
 
         return div;


### PR DESCRIPTION
Arrows in the sequence diagrams use SVG-markers for the message arrows, and since the extension has to have to the DOM both the light and the dark diagrams and hide the less relevant one, it used to produce conflicts which confuse the rendering engine into using the hidden light arrows for the dark diagram.
Sandboxing the images within img tags resolves the issue.

Refs: https://github.com/jaime-olivares/yuml-diagram/issues/10
Fixes: https://github.com/jaime-olivares/vscode-yuml/issues/50