### PR TITLE
snippets: fix sequence diagram typo

### DIFF
--- a/snippets/yuml.json
+++ b/snippets/yuml.json
@@ -109,7 +109,7 @@
         "prefix": "sequence",
         "body": [
             "// {type:sequence}",
-            "[:Computer]sendUnsentEmal>[:Server]",
+            "[:Computer]sendUnsentEmail>[:Server]",
             "[:Computer]newEmail>[:Server]",
             "[:Server]reponse.>[:Computer]",
             "[:Computer]downloadEmail>[:Server]",


### PR DESCRIPTION
I noticed today while using the sequence diagram snippet that email was spelled incorrectly. 

Hope this helps!